### PR TITLE
Fix: Move metadata from client component to layout

### DIFF
--- a/src/app/download/layout.tsx
+++ b/src/app/download/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import React from 'react';
+
+export const metadata: Metadata = {
+  title: 'Download CareerSuite.ai - Free AI Resume Analyzer',
+  description: 'Download the CareerSuite.ai browser extension for free. Get instant AI-powered feedback to tailor your resume and beat ATS. Private and no account needed.',
+};
+
+export default function DownloadLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/download/page.tsx
+++ b/src/app/download/page.tsx
@@ -1,14 +1,8 @@
 // src/app/download/page.tsx
 'use client'; // Add this directive
 
-import type { Metadata } from 'next';
 import { Button } from '@/components/ui/button';
 import { DownloadCloud, ChromeIcon, CheckCircle, ShieldCheck } from 'lucide-react'; // Added ShieldCheck for privacy
-
-export const metadata: Metadata = {
-  title: 'Download CareerSuite.ai - Free AI Resume Analyzer',
-  description: 'Download the CareerSuite.ai browser extension for free. Get instant AI-powered feedback to tailor your resume and beat ATS. Private and no account needed.',
-};
 
 export default function DownloadPage() {
   // IMPORTANT: Replace with your actual Chrome Web Store extension link


### PR DESCRIPTION
Moved the metadata export from `src/app/download/page.tsx` (a client component) to a new server component `src/app/download/layout.tsx`.

This resolves the Vercel build error "You are attempting to export \"metadata\" from a component marked with \"use client\", which is disallowed."